### PR TITLE
Feature: Add support for string concatenation

### DIFF
--- a/src/colorist/__main__.py
+++ b/src/colorist/__main__.py
@@ -134,25 +134,25 @@ def bg_bright_black(text: str) -> None:
     helper.print.color(text, bgcolor=BgBrightColor.BLACK)
 
 
-def effect_bold(text: str, color: Color | BrightColor = Color.DEFAULT) -> None:
+def effect_bold(text: str, color: Color | BrightColor | str = Color.DEFAULT) -> None:
     helper.print.effect(text, Effect.BOLD, color)
 
 
-def effect_dim(text: str, color: Color | BrightColor = Color.DEFAULT) -> None:
+def effect_dim(text: str, color: Color | BrightColor | str = Color.DEFAULT) -> None:
     helper.print.effect(text, Effect.DIM, color)
 
 
-def effect_underline(text: str, color: Color | BrightColor = Color.DEFAULT) -> None:
+def effect_underline(text: str, color: Color | BrightColor | str = Color.DEFAULT) -> None:
     helper.print.effect(text, Effect.UNDERLINE, color)
 
 
-def effect_blink(text: str, color: Color | BrightColor = Color.DEFAULT) -> None:
+def effect_blink(text: str, color: Color | BrightColor | str = Color.DEFAULT) -> None:
     helper.print.effect(text, Effect.BLINK, color)
 
 
-def effect_reverse(text: str, color: Color | BrightColor = Color.DEFAULT) -> None:
+def effect_reverse(text: str, color: Color | BrightColor | str = Color.DEFAULT) -> None:
     helper.print.effect(text, Effect.REVERSE, color)
 
 
-def effect_hide(text: str, color: Color | BrightColor = Color.DEFAULT) -> None:
+def effect_hide(text: str, color: Color | BrightColor | str = Color.DEFAULT) -> None:
     helper.print.effect(text, Effect.HIDE, color)

--- a/src/colorist/helper/print.py
+++ b/src/colorist/helper/print.py
@@ -9,5 +9,5 @@ def color(text: str, color: Color | BrightColor | str = "", bgcolor: BgColor | B
     print(f"{bgcolor}{color}{text}{Color.OFF}")
 
 
-def effect(text: str, effect: Effect, color: Color | BrightColor = Color.DEFAULT) -> None:
+def effect(text: str, effect: Effect | str, color: Color | BrightColor | str = Color.DEFAULT) -> None:
     print(f"{color}{effect}{text}{Effect.OFF}")

--- a/src/colorist/model/background_bright_color.py
+++ b/src/colorist/model/background_bright_color.py
@@ -1,11 +1,8 @@
-from enum import Enum, unique
-
 from .background_color import BgColor
 from .color import Color
 
 
-@unique
-class BgBrightColor(Enum):
+class BgBrightColor():
     """Options for bright background colors. Implements ANSI escape codes for printing color, effects, and styling to the terminal.
 
     Reference: https://en.wikipedia.org/wiki/ANSI_escape_code"""
@@ -20,6 +17,3 @@ class BgBrightColor(Enum):
     BLACK = "\033[100m"
     DEFAULT = BgColor.DEFAULT
     OFF = Color.OFF
-
-    def __str__(self) -> str:
-        return str(self.value)

--- a/src/colorist/model/background_color.py
+++ b/src/colorist/model/background_color.py
@@ -1,10 +1,7 @@
-from enum import Enum, unique
-
 from .color import Color
 
 
-@unique
-class BgColor(Enum):
+class BgColor():
     """Options for standard background colors. Implements ANSI escape codes for printing color, effects, and styling to the terminal.
 
     Reference: https://en.wikipedia.org/wiki/ANSI_escape_code"""
@@ -19,6 +16,3 @@ class BgColor(Enum):
     BLACK = "\033[40m"
     DEFAULT = "\033[49m"
     OFF = Color.OFF
-
-    def __str__(self) -> str:
-        return str(self.value)

--- a/src/colorist/model/bright_color.py
+++ b/src/colorist/model/bright_color.py
@@ -1,10 +1,7 @@
-from enum import Enum, unique
-
 from .color import Color
 
 
-@unique
-class BrightColor(Enum):
+class BrightColor():
     """Options for bright colors. Implements ANSI escape codes for printing color, effects, and styling to the terminal.
 
     Reference: https://en.wikipedia.org/wiki/ANSI_escape_code"""
@@ -19,6 +16,3 @@ class BrightColor(Enum):
     BLACK = "\033[90m"
     DEFAULT = Color.DEFAULT
     OFF = Color.OFF
-
-    def __str__(self) -> str:
-        return str(self.value)

--- a/src/colorist/model/color.py
+++ b/src/colorist/model/color.py
@@ -1,8 +1,4 @@
-from enum import Enum, unique
-
-
-@unique
-class Color(Enum):
+class Color():
     """Options for standard colors. Implements ANSI escape codes for printing color, effects, and styling to the terminal.
 
     Reference: https://en.wikipedia.org/wiki/ANSI_escape_code"""
@@ -17,6 +13,3 @@ class Color(Enum):
     BLACK = "\033[30m"
     DEFAULT = "\033[39m"
     OFF = "\033[0m"
-
-    def __str__(self) -> str:
-        return str(self.value)

--- a/src/colorist/model/effect.py
+++ b/src/colorist/model/effect.py
@@ -1,10 +1,7 @@
-from enum import Enum, unique
-
 from .color import Color
 
 
-@unique
-class Effect(Enum):
+class Effect():
     """Options for effects and styling. Implements ANSI escape codes for printing color, effects, and styling to the terminal.
 
     Reference: https://en.wikipedia.org/wiki/ANSI_escape_code"""
@@ -23,6 +20,3 @@ class Effect(Enum):
     REVERSE_OFF = "\033[27m"
     HIDE_OFF = "\033[28m"
     OFF = Color.OFF
-
-    def __str__(self) -> str:
-        return str(self.value)

--- a/test/background_bright_color/custom_background_bright_color_test.py
+++ b/test/background_bright_color/custom_background_bright_color_test.py
@@ -2,8 +2,16 @@ import terminal
 
 from colorist import BgBrightColor
 
+CYAN_BG_TEXT = "I want \033[106mcyan\033[0m background color inside this paragraph\n"
+
 
 def test_custom_text_background_color_1(capfd: object) -> None:
     print(f"I want {BgBrightColor.CYAN}cyan{BgBrightColor.OFF} background color inside this paragraph")
     terminal_output = terminal.get_output(capfd)
-    assert terminal_output == "I want \033[106mcyan\033[0m background color inside this paragraph\n"
+    assert terminal_output == CYAN_BG_TEXT
+
+
+def test_custom_text_background_color_1_string_concatenation(capfd: object) -> None:
+    print("I want " + BgBrightColor.CYAN + "cyan" + BgBrightColor.OFF + " background color inside this paragraph")
+    terminal_output = terminal.get_output(capfd)
+    assert terminal_output == CYAN_BG_TEXT

--- a/test/background_color/custom_background_color_test.py
+++ b/test/background_color/custom_background_color_test.py
@@ -2,6 +2,8 @@ import terminal
 
 from colorist import BgColor
 
+BG_COLOR_TEXT = "Both \033[42mgreen\033[0m and \033[43myellow\033[0m are nice background colors\n"
+
 
 def test_custom_text_background_color_1(capfd: object) -> None:
     print(f"I want {BgColor.RED}red{BgColor.OFF} background color inside this paragraph")
@@ -12,4 +14,10 @@ def test_custom_text_background_color_1(capfd: object) -> None:
 def test_custom_text_background_color_2(capfd: object) -> None:
     print(f"Both {BgColor.GREEN}green{BgColor.OFF} and {BgColor.YELLOW}yellow{BgColor.OFF} are nice background colors")
     terminal_output = terminal.get_output(capfd)
-    assert terminal_output == "Both \033[42mgreen\033[0m and \033[43myellow\033[0m are nice background colors\n"
+    assert terminal_output == BG_COLOR_TEXT
+
+
+def test_custom_text_background_color_2_string_concatenation(capfd: object) -> None:
+    print("Both " + BgColor.GREEN + "green" + BgColor.OFF + " and " + BgColor.YELLOW + "yellow" + BgColor.OFF + " are nice background colors")
+    terminal_output = terminal.get_output(capfd)
+    assert terminal_output == BG_COLOR_TEXT

--- a/test/bright_color/custom_bright_color_test.py
+++ b/test/bright_color/custom_bright_color_test.py
@@ -2,8 +2,16 @@ import terminal
 
 from colorist import BrightColor
 
+CYAN_TEXT = "I want \033[96mcyan\033[0m color inside this paragraph\n"
+
 
 def test_custom_text_color_1(capfd: object) -> None:
     print(f"I want {BrightColor.CYAN}cyan{BrightColor.OFF} color inside this paragraph")
     terminal_output = terminal.get_output(capfd)
-    assert terminal_output == "I want \033[96mcyan\033[0m color inside this paragraph\n"
+    assert terminal_output == CYAN_TEXT
+
+
+def test_custom_text_color_1_string_concatenation(capfd: object) -> None:
+    print("I want " + BrightColor.CYAN + "cyan" + BrightColor.OFF + " color inside this paragraph")
+    terminal_output = terminal.get_output(capfd)
+    assert terminal_output == CYAN_TEXT

--- a/test/color/custom_color_test.py
+++ b/test/color/custom_color_test.py
@@ -2,13 +2,13 @@ import terminal
 
 from colorist import Color
 
-_red_text = "I want \033[31mred\033[0m color inside this paragraph\n"
+RED_TEXT = "I want \033[31mred\033[0m color inside this paragraph\n"
 
 
 def test_custom_text_color_1(capfd: object) -> None:
     print(f"I want {Color.RED}red{Color.OFF} color inside this paragraph")
     terminal_output = terminal.get_output(capfd)
-    assert terminal_output == _red_text
+    assert terminal_output == RED_TEXT
 
 
 def test_custom_text_color_2(capfd: object) -> None:
@@ -20,4 +20,4 @@ def test_custom_text_color_2(capfd: object) -> None:
 def test_custom_text_color_string_concatenation(capfd: object) -> None:
     print(f"I want {Color.RED}red{Color.OFF} color inside this paragraph")
     terminal_output = terminal.get_output(capfd)
-    assert terminal_output == _red_text
+    assert terminal_output == RED_TEXT

--- a/test/color/custom_color_test.py
+++ b/test/color/custom_color_test.py
@@ -17,7 +17,7 @@ def test_custom_text_color_2(capfd: object) -> None:
     assert terminal_output == "Both \033[32mgreen\033[0m and \033[33myellow\033[0m are nice colors\n"
 
 
-def test_custom_text_color_string_concatenation(capfd: object) -> None:
+def test_custom_text_color_1_string_concatenation(capfd: object) -> None:
     print("I want " + Color.RED + "red" + Color.OFF + " color inside this paragraph")
     terminal_output = terminal.get_output(capfd)
     assert terminal_output == RED_TEXT

--- a/test/color/custom_color_test.py
+++ b/test/color/custom_color_test.py
@@ -18,6 +18,6 @@ def test_custom_text_color_2(capfd: object) -> None:
 
 
 def test_custom_text_color_string_concatenation(capfd: object) -> None:
-    print(f"I want {Color.RED}red{Color.OFF} color inside this paragraph")
+    print("I want " + Color.RED + "red" + Color.OFF + " color inside this paragraph")
     terminal_output = terminal.get_output(capfd)
     assert terminal_output == RED_TEXT

--- a/test/color/custom_color_test.py
+++ b/test/color/custom_color_test.py
@@ -11,13 +11,13 @@ def test_custom_text_color_1(capfd: object) -> None:
     assert terminal_output == RED_TEXT
 
 
-def test_custom_text_color_2(capfd: object) -> None:
-    print(f"Both {Color.GREEN}green{Color.OFF} and {Color.YELLOW}yellow{Color.OFF} are nice colors")
-    terminal_output = terminal.get_output(capfd)
-    assert terminal_output == "Both \033[32mgreen\033[0m and \033[33myellow\033[0m are nice colors\n"
-
-
 def test_custom_text_color_1_string_concatenation(capfd: object) -> None:
     print("I want " + Color.RED + "red" + Color.OFF + " color inside this paragraph")
     terminal_output = terminal.get_output(capfd)
     assert terminal_output == RED_TEXT
+
+
+def test_custom_text_color_2(capfd: object) -> None:
+    print(f"Both {Color.GREEN}green{Color.OFF} and {Color.YELLOW}yellow{Color.OFF} are nice colors")
+    terminal_output = terminal.get_output(capfd)
+    assert terminal_output == "Both \033[32mgreen\033[0m and \033[33myellow\033[0m are nice colors\n"

--- a/test/effect/custom_effect_test.py
+++ b/test/effect/custom_effect_test.py
@@ -2,6 +2,8 @@ import terminal
 
 from colorist import Color, Effect
 
+EFFECT_TEXT = "I want both \033[31mcolored and \033[5mblinking\033[25m text\033[0m inside this paragraph\n"
+
 
 def test_custom_text_effect_1(capfd: object) -> None:
     print(f"I want {Effect.UNDERLINE}underlined text{Effect.UNDERLINE_OFF} inside this paragraph")
@@ -18,4 +20,10 @@ def test_custom_text_effect_2(capfd: object) -> None:
 def test_custom_text_effect_3(capfd: object) -> None:
     print(f"I want both {Color.RED}colored and {Effect.BLINK}blinking{Effect.BLINK_OFF} text{Color.OFF} inside this paragraph")
     terminal_output = terminal.get_output(capfd)
-    assert terminal_output == "I want both \033[31mcolored and \033[5mblinking\033[25m text\033[0m inside this paragraph\n"
+    assert terminal_output == EFFECT_TEXT
+
+
+def test_custom_text_effect_3_string_concatenation(capfd: object) -> None:
+    print("I want both " + Color.RED + "colored and " + Effect.BLINK + "blinking" + Effect.BLINK_OFF + " text" + Color.OFF + " inside this paragraph")
+    terminal_output = terminal.get_output(capfd)
+    assert terminal_output == EFFECT_TEXT


### PR DESCRIPTION
Previously only f-strings worked:

```python
from colorist import Color

print(f"{Color.RED}This text is red in color{Color.OFF}")
```

But string concatenation would fail:

```python
from colorist import Color

print(Color.RED + "This text is red in color" + Color.OFF)
```
