### PR TITLE
Fix: Missing images on documentation site on GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fix/missing-images-on-github-pages-documentation
 
 permissions:
   contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - fix/missing-images-on-github-pages-documentation
 
 permissions:
   contents: write


### PR DESCRIPTION
Images display locally...

<img width="1312" alt="Screenshot 2023-12-03 at 05 54 03" src="https://github.com/jakob-bagterp/colorist-for-python/assets/25110864/4b0b4fd8-5fec-4814-97d0-75f0084a387a">

... but not when deployed to GitHub Pages, maybe due to missing support of LFS.

<img width="1250" alt="Screenshot 2023-12-03 at 05 55 03" src="https://github.com/jakob-bagterp/colorist-for-python/assets/25110864/3ff4f352-cfeb-4752-b9e7-fddcab17dbc4">